### PR TITLE
Fixed canonical Psalm title markers

### DIFF
--- a/Psalms/100/data
+++ b/Psalms/100/data
@@ -1,6 +1,6 @@
 \c 100
 \s Rwiyo rwekuvonga musiki
-\p Pisarema rekurumbidza.
+\d Pisarema rekurumbidza.
 \p
 \v 1 Pururudzai kuna Jehovha\x + Map. 95.1.\x*, imwi nyika yose\x + Map. 95.1.\x*.
 \v 2 Shumirai Jehovha nemufaro; uyai pamberi pake nekuimba nemufaro\x + Map. 2.11.\x*.

--- a/Psalms/101/data
+++ b/Psalms/101/data
@@ -1,6 +1,6 @@
 \c 101
 \s Dhavhidhi anovimbisa kufamba nenzira yakanaka
-\p Pisarema raDhavhidhi.
+\d Pisarema raDhavhidhi.
 \p
 \v 1 Ndichaimba zvetsitsi nemutongo; ndichakuimbirai rumbidzo, Jehovha.
 \v 2 Ndichazvibata neuchenjeri nenzira yakarurama\x + Dhan. 1.4. 9.13. 1 Sam. 18.5.\x*. Muchauya rinhi kwandiri\x + Map. 119.82.\x*\x + 1 Madz. 9.4.\x*? Ndichafamba muuchokwadi hwemoyo wangu mukati meimba yangu\x + 1 Madz. 9.4.\x*\x + Map. 78.72.\x*.

--- a/Psalms/102/data
+++ b/Psalms/102/data
@@ -1,6 +1,6 @@
 \c 102
 \s Kuchema kwemunhu ari pakutambudzika
-\p Munyengetero weanotambudzika kana achikundikana achidurura zvichemo zvake pamberi paJehovha.
+\d Munyengetero weanotambudzika kana achikundikana achidurura zvichemo zvake pamberi paJehovha.
 \p
 \v 1 Jehovha, inzwai munyengetero wangu\x + Map. 39.12.\x*; uye kuchema kwangu\x + Job. 19.7.\x* ngakusvikire kwamuri\x + 1 Sam. 9.16. Map. 18.6.\x*.
 \v 2 Regai kundivanzira chiso chenyu\x + Map. 27.9.\x*; pazuva randiri mudambudziko\x + Map. 66.14.\x* rerekerai nzeve yenyu kwandiri\x + Map. 86.1.\x*; pazuva randinodana\x + Map. 56.9.\x* kurumidzai kundipindura\x + Map. 69.17.\x*.

--- a/Psalms/108/data
+++ b/Psalms/108/data
@@ -1,6 +1,6 @@
 \c 108
 \s Munyengetero wekukumbira kubatsirwa kukunda
-\p Rwiyo. Pisarema raDhavhidhi.
+\d Rwiyo. Pisarema raDhavhidhi.
 \p
 \v 1 Moyo wangu wakasimba, Mwari; ndichaimba, zvirokwazvo ndichaimba rumbidzo, hongu rukudzo rwangu!
 \p

--- a/Psalms/109/data
+++ b/Psalms/109/data
@@ -1,6 +1,6 @@
 \c 109
 \s Munyengetero wekukumbira kutsiviwa kwevavengi
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Mwari werumbidzo yangu, regai kunyarara.
 \v 2 Nokuti muromo wewakaipa nemuromo weunyengeri yakazarukira ini; vakataura neni nerurimi rwenhema.

--- a/Psalms/11/data
+++ b/Psalms/11/data
@@ -1,6 +1,6 @@
 \c 11
 \s Mwari utiziro hwevakarurama
-\p Kumutungamiriri wekuimba. \add Pisarema\add* raDhavhidhi.
+\d Kumutungamiriri wekuimba. \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Ndinovimba naJehovha\x + Map. 25.2.\x*; munoreva sei kumweya wangu: Tizira kugomo renyu \add se\add*shiri\x + 1 Sam. 23.14,19. 26.19,20.\x*?
 \v 2 Nokuti tarira, vakaipa vanobwembura uta\x + Map. 7.12. Map. 64.4.\x*, vanogadzira museve wavo parusungiso\x + Map. 7.12. 21.12.\x*, kuti vafure kune vakarurama pamoyo murima\x + Map. 7.10.\x*.

--- a/Psalms/110/data
+++ b/Psalms/110/data
@@ -1,6 +1,6 @@
 \c 110
 \s Umambo neupristi hwaMesiasi
-\p Pisarema raDhavhidhi.
+\d Pisarema raDhavhidhi.
 \p
 \v 1 Jehovha wakati kuna Ishe wangu: Gara kurudyi rwangu, kusvika ndaita vavengi vako chitsiko chetsoka dzako.
 \v 2 Jehovha achatuma tsvimbo yesimba rako kubva paZiyoni, \add achiti\add*: Tonga pakati pevavengi vako.

--- a/Psalms/12/data
+++ b/Psalms/12/data
@@ -1,6 +1,6 @@
 \c 12
 \s Munyengetero wekukumbira rubatsiro kuna Mwari
-\p Kumutungamiriri wekuimba; neSheminiti. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba; neSheminiti. Pisarema raDhavhidhi.
 \p
 \v 1 Ponesai, Jehovha, nokuti anoda Mwari woguma; nokuti vakatendeka vonyangarika pakati pevana vevanhu\x + Isa. 57.1. Mik. 7.2. Map. 50.5.\x*.
 \v 2 Vanotaura zvisina maturo, umwe neumwe newekwake\x + Map. 41.6. 144.8.\x*; muromo weunyengeri; vanotaura nemoyo miviri\x + 12.3. Map. 5.9. 36.2,3. Dhan. 11.32. Map. 28.3.\x*.

--- a/Psalms/120/data
+++ b/Psalms/120/data
@@ -1,6 +1,6 @@
 \c 120
 \s Munyengetero wekukumbira kununurwa
-\p Rwiyo rwekukwira.
+\d Rwiyo rwekukwira.
 \p
 \v 1 Pakutambudzika kwangu ndakadana kuna Jehovha, zvino akandipindura.
 \v 2 Nunurai mweya wangu, Jehovha, kubva pamuromo unoreva nhema, parurimi rwunonyengera.

--- a/Psalms/121/data
+++ b/Psalms/121/data
@@ -1,6 +1,6 @@
 \c 121
 \s Jehovha ndiye muperekedzi parwendo
-\p Rwiyo rwekukwira.
+\d Rwiyo rwekukwira.
 \p
 \v 1 Ndichasimudzira meso angu kumakomo; uko kunobva rubatsiro rwangu.
 \v 2 Rubatsiro rwangu rwunobva kuna Jehovha, wakaita matenga nenyika.

--- a/Psalms/122/data
+++ b/Psalms/122/data
@@ -1,6 +1,6 @@
 \c 122
 \s Jerusarema guta rinodikanwa
-\p Rwiyo rwekukwira; rwaDhavhidhi.
+\d Rwiyo rwekukwira; rwaDhavhidhi.
 \p
 \v 1 Ndakafara pavakati kwandiri: Ngatiende kuimba yaJehovha.
 \v 2 Tsoka dzedu dzimire mumasuwo ako, Jerusarema.

--- a/Psalms/123/data
+++ b/Psalms/123/data
@@ -1,6 +1,6 @@
 \c 123
 \s Tarirai kuna Jehovha, muvimbe naye
-\p Rwiyo rwekukwira.
+\d Rwiyo rwekukwira.
 \p
 \v 1 Ndinosimudzira meso angu kwamuri, imwi munogara kumatenga.
 \v 2 Tarirai, meso evarandarume sezvaari paruoko rwatenzi wavo, meso emurandakadzi sezvaari paruoko rwatenzikadzi wake; saizvozvo meso edu ari kuna Jehovha Mwari wedu, kusvika atinzwira tsitsi.

--- a/Psalms/124/data
+++ b/Psalms/124/data
@@ -1,6 +1,6 @@
 \c 124
 \s Murwiri waIsraeri ngaarumbidzwe
-\p Rwiyo rwekukwira; rwaDhavhidhi.
+\d Rwiyo rwekukwira; rwaDhavhidhi.
 \p
 \v 1 Dai aiva asiri Jehovha waiva nesu, Israeri ngaadaro;
 \v 2 dai aiva asiri Jehovha waiva nesu, vanhu pavaitimukira;

--- a/Psalms/125/data
+++ b/Psalms/125/data
@@ -1,6 +1,6 @@
 \c 125
 \s Jehovha anochengetedza vanhu vake
-\p Rwiyo rwekukwira.
+\d Rwiyo rwekukwira.
 \p
 \v 1 Vanovimba naJehovha \add vakaita\add* segomo reZiyoni, \add ri\add*singazununguki, rimire kusvika nekusingaperi.
 \v 2 Makomo akapoteredza Jerusarema; saizvozvo Jehovha anopoteredza vanhu vake kubva ikozvino uye kusvika rinhi narinhi.

--- a/Psalms/126/data
+++ b/Psalms/126/data
@@ -1,6 +1,6 @@
 \c 126
 \s Kuvonga Jehovha nekudzosa kwake vatapwa paZiyoni
-\p Rwiyo rwekukwira.
+\d Rwiyo rwekukwira.
 \p
 \v 1 Pakudzosa kwaJehovha nhapwa dzeZiyoni, takava sevanorota.
 \v 2 Ipapo muromo wedu wakazara kuseka, nerurimi rwedu kuimba. Ipapo vakati pakati pevahedheni: Jehovha wakavaitira zvinhu zvikuru.

--- a/Psalms/127/data
+++ b/Psalms/127/data
@@ -1,6 +1,6 @@
 \c 127
 \s Maropafadzo ese anobva kuna Jehovha
-\p Rwiyo rwekukwira; rwaSoromoni.
+\d Rwiyo rwekukwira; rwaSoromoni.
 \p
 \v 1 Kana Jehovha asingavaki imba, vanoivaka vanoita pasina; kana Jehovha asingachengeti guta, murindi anorindira pasina.
 \v 2 Hazvina maturo kuti mumuke mangwanani, mugare kusvika hwava usiku, mudye zvekudya zvekutamburira; saizvozvo anopa hope mudikanwi wake.

--- a/Psalms/128/data
+++ b/Psalms/128/data
@@ -1,6 +1,6 @@
 \c 128
 \s Kuropafadzwa kwemunhu wakarurama
-\p Rwiyo rwekukwira.
+\d Rwiyo rwekukwira.
 \p
 \v 1 Wakaropafadzwa wose anotya Jehovha, anofamba munzira dzake.
 \v 2 Nokuti iwe uchadya kubata kwemaoko ako; uchafara, uye zvichava zvakanaka kwauri.

--- a/Psalms/129/data
+++ b/Psalms/129/data
@@ -1,6 +1,6 @@
 \c 129
 \s Kunyengeterera kuparadzwa kwevanovenga Ziyoni
-\p Rwiyo rwekukwira.
+\d Rwiyo rwekukwira.
 \p
 \v 1 Kazhinji vakanditambudza kubva paudiki hwangu, Israeri ngaadaro hake.
 \v 2 Kazhinji vakanditambudza kubva paudiki hwangu; zvakadaro havana kundikunda.

--- a/Psalms/13/data
+++ b/Psalms/13/data
@@ -1,6 +1,6 @@
 \c 13
 \s Munyengetero wekukumbira rubatsiro
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Kusvika rinhi Jehovha muchindikanganwa\x + Map. 79.5. 89.46.\x* nekusingaperi\x + Map. 79.5. 89.46.\x*? Kusvika rinhi muchindivanzira chiso chenyu\x + Job. 13.24. Map. 89.46.\x*?
 \v 2 Kusvika rinhi ndichiisa mazano mumweya wangu, kusuruvara mumoyo mangu nezuva? Kusvika rinhi muvengi wangu achikwiridzirwa pamusoro pangu?

--- a/Psalms/130/data
+++ b/Psalms/130/data
@@ -1,6 +1,6 @@
 \c 130
 \s Munyengetero wekukumbira kanganwiro nekununurwa
-\p Rwiyo rwekukwira.
+\d Rwiyo rwekukwira.
 \p
 \v 1 Ndiri muudziku ndakadanidzira kwamuri, Jehovha.
 \v 2 Ishe, inzwai inzwi rangu; nzeve dzenyu ngadziteerere inzwi remikumbiro yangu.

--- a/Psalms/131/data
+++ b/Psalms/131/data
@@ -1,6 +1,6 @@
 \c 131
 \s Rugare muna Jehovha
-\p Rwiyo rwekukwira rwaDhavhidhi.
+\d Rwiyo rwekukwira rwaDhavhidhi.
 \p
 \v 1 Jehovha, moyo wangu hau\add zvi\add*kudzi, uye meso angu haakwiriri, uye handina kufamba pazvinhu zvakakura nepazvinhu zvinoshamisa kwazvo kwandiri.
 \v 2 Zvirokwazvo ndakadzikamisa uye ndakanyaradza mweya wangu, seanorumurwa kuna mai vake; mweya wangu wakaita seakarumurwa mandiri.

--- a/Psalms/132/data
+++ b/Psalms/132/data
@@ -1,6 +1,6 @@
 \c 132
 \s Chivimbiso chaDhavhidhi nechivimbiso chaJehovha
-\p Rwiyo rwekukwira.
+\d Rwiyo rwekukwira.
 \p
 \v 1 Jehovha, rangarirai Dhavhidhi, matambudziko ake ose.
 \v 2 Kuti wakapika kuna Jehovha, wakavimbisa kuna Wemasimbaose waJakove, \add achiti\add*:

--- a/Psalms/133/data
+++ b/Psalms/133/data
@@ -1,6 +1,6 @@
 \c 133
 \s Kunaka kwerudo pakati pehama
-\p Rwiyo rwekukwira; rwaDhavhidhi.
+\d Rwiyo rwekukwira; rwaDhavhidhi.
 \p
 \v 1 Tarirai, zvakanaka sei uye kunofadza sei kugara pamwe kwehama, iko kubatana.
 \v 2 Zvakafanana nemafuta akanaka, pamusoro pemusoro, achiburukira pandebvu, ndebvu dzaAroni, anoburukira kumupendero wenguvo dzake.

--- a/Psalms/134/data
+++ b/Psalms/134/data
@@ -1,6 +1,6 @@
 \c 134
 \s Vanoshumira ngavavonge Jehovha
-\p Rwiyo rwekukwira.
+\d Rwiyo rwekukwira.
 \p
 \v 1 Tarirai, rumbidzai Jehovha, imwi varanda vese vaJehovha, imwi munomira usiku uzhinji mumba maJehovha.
 \v 2 Simudzirai maoko enyu \add ku\add*nzvimbo tsvene, uye murumbidze Jehovha.

--- a/Psalms/139/data
+++ b/Psalms/139/data
@@ -1,6 +1,6 @@
 \c 139
 \s Jehovha muzivi nemuoni wezvese
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Jehovha, makandinzvera, uye muno\add ndi\add*ziva.
 \v 2 Imwi munoziva kugara kwangu pasi nekusimuka kwangu; munonzwisisa murangariro wangu muri kure.

--- a/Psalms/14/data
+++ b/Psalms/14/data
@@ -1,6 +1,6 @@
 \c 14
 \s Upenzi nekuipa kwemunhu
-\p Kumutungamiriri wekuimba. \add Pisarema\add* raDhavhidhi.
+\d Kumutungamiriri wekuimba. \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Benzi\x + Map. 53.1-6.\x* rakati mumoyo maro\x + 1 Sam. 25.25. Vato. 19.23.\x*: Hakuna Mwari\x + Map. 10. 4.\x*. Vakaora, vakaita basa rinonyangadza\x + Gen.. 6.5,11,12.\x*; hapana anoita zvakanaka\x + VaRom. 3.10-12.\x*.
 \v 2 Jehovha wakatarisa pasi ari kumatenga pamusoro pevanakomana vevanhu\x + Map. 102.19. Map. 11.4.\x* kuona kana aripo\x + VaRom. 3.10-12.\x* anonzwisisa\x + Job. 22.2.\x*, anotsvaka Mwari\x + Map. 10.4.\x*.

--- a/Psalms/140/data
+++ b/Psalms/140/data
@@ -1,6 +1,6 @@
 \c 140
 \s Dhavhidhi anonyengetera kuti arwirwe pavavengi vake
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Ndinunurei, Jehovha, kubva pamunhu wakaipa; ndichengetedzei kubva pamurume ane hasha zhinji.
 \v 2 Ivo, vanoronga zvakaipa mumoyo; zuva rese vanounganira dzihondo.

--- a/Psalms/141/data
+++ b/Psalms/141/data
@@ -1,6 +1,6 @@
 \c 141
 \s Munyengetero wekukumbira kuchengetedzwa
-\p Pisarema raDhavhidhi.
+\d Pisarema raDhavhidhi.
 \p
 \v 1 Jehovha, ndinochema kwamuri; kurumidzai kwandiri; ipai nzeve kuinzwi rangu kana ndichidana kwamuri.
 \v 2 Munyengetero wangu ngaumiswe sezvipfungaidzo zvinonhuhwira pamberi penyu, kusimudza maoko kwangu \add se\add*chipo chemadekwani.

--- a/Psalms/142/data
+++ b/Psalms/142/data
@@ -1,6 +1,6 @@
 \c 142
 \s Munyengetero wekukumbira kubatsirwa padambudziko
-\p Masikiri yaDhavhidhi, munyengetero, paakanga ari mubako.
+\d Masikiri yaDhavhidhi, munyengetero, paakanga ari mubako.
 \p
 \v 1 Ndinodana kuna Jehovha \add ne\add*nzwi rangu; ndinonyengetera \add ne\add*nzwi rangu kuna Jehovha.
 \v 2 Ndinodurura chichemo changu pamberi pake; ndinozivisa kutambudzika kwangu pamberi pake.

--- a/Psalms/143/data
+++ b/Psalms/143/data
@@ -1,6 +1,6 @@
 \c 143
 \s Munyengetero wekukumbira kununurwa nekunzverwa
-\p Pisarema raDhavhidhi.
+\d Pisarema raDhavhidhi.
 \p
 \v 1 Jehovha, inzwai munyengetero wangu; ipai nzeve kumikumbiro yangu; ndipindurei mukutendeka kwenyu mukururama kwenyu.
 \v 2 Regai kupinda pamutongo nemuranda wenyu. Nokuti hakuna mupenyu anonzi haana mhosva pamberi penyu.

--- a/Psalms/145/data
+++ b/Psalms/145/data
@@ -1,6 +1,6 @@
 \c 145
 \s Kurumbidza Jehovha paukuru hwake nenyasha dzake
-\p Rwiyo rwekurumbidza rwaDhavhidhi.
+\d Rwiyo rwekurumbidza rwaDhavhidhi.
 \p
 \v 1 Ndichakusimudzirai, Mwari wangu, Mambo; nekurumbidza zita renyu kusvika rinhi narinhi.
 \v 2 Ndichakurumbidzai nezuva rimwe nerimwe, nekukudza zita renyu kusvika rinhi narinhi.

--- a/Psalms/15/data
+++ b/Psalms/15/data
@@ -1,6 +1,6 @@
 \c 15
 \s Munhu angagara mutende raJehovha?
-\p Pisarema raDhavhidhi.
+\d Pisarema raDhavhidhi.
 \p
 \v 1 Jehovha, ndiani achagara mutende renyu\x + Map. 24.3,4. Isa. 33.16.\x*? Ndiani angagara pagomo renyu dzvene\x + Map. 2.6.\x*?
 \v 2 Uyo anofamba asina mhosva\x + Isa. 33.15.\x*, uye anoita zvakarurama\x + Map. 106.3.\x*, uye anotaura chokwadi mumoyo make\x + Zek. 8.16. VaEfe. 4.25. Joh. 1.47. VaKoro. 3.9.\x*.

--- a/Psalms/16/data
+++ b/Psalms/16/data
@@ -1,6 +1,6 @@
 \c 16
 \s Jehovha mugove wangu
-\p Mikitami yaDhavhidhi.
+\d Mikitami yaDhavhidhi.
 \p
 \v 1 Ndichengetedzei, Mwari, nokuti ndinovimba nemwi\x + Map. 25.20.\x*.
 \v 2 Ndakati kuna Jehovha: Ndimwi Ishe wangu; kunaka kwangu hakusviki kwamuri\x + Job. 22.2. Map. 50.9,10. VaRom. 11.35.\x*.

--- a/Psalms/17/data
+++ b/Psalms/17/data
@@ -1,6 +1,6 @@
 \c 17
 \s Munyengetero pakutambudzwa asina mhosva
-\p Munyengetero waDhavhidhi.
+\d Munyengetero waDhavhidhi.
 \p
 \v 1 Inzwai kururama Jehovha; muteerere kuchema kwangu\x + Map. 142.6.\x*; ipai nzeve kumunyengetero wangu, kwete kubva pamiromo inonyengera.
 \v 2 Mutongo wangu ngaubude kubva pakuvapo kwenyu\x + Map. 11.7.\x*; meso enyu ngaaone zvinhu zvakarurama\x + 1 Makor. 29.17. Map. 58.1. 75.2. 99.4. Zvir. 1.3. 2.9. 8.6. 23.16. Isa. 26.7. 33.15. 45.19. Dhan. 11.6. Map. 9.8.\x*.

--- a/Psalms/18/data
+++ b/Psalms/18/data
@@ -1,6 +1,6 @@
 \c 18
 \s Rwiyo rwaDhavhidhi rwekuvonga Jehovha pakununurwa
-\p Kumutungamiriri wekuimba. \add Pisarema\add* raDhavhidhi, muranda waJehovha, wakataura\x + Map. 36.\x* kuna Jehovha mashoko erwiyo urwu nezuva Jehovha raakamununura paruoko rwevavengi vake vese paruoko\x + 2 Sam. 22.1-51.\x* rwaSauro.
+\d Kumutungamiriri wekuimba. \add Pisarema\add* raDhavhidhi, muranda waJehovha, wakataura\x + Map. 36.\x* kuna Jehovha mashoko erwiyo urwu nezuva Jehovha raakamununura paruoko rwevavengi vake vese paruoko\x + 2 Sam. 22.1-51.\x* rwaSauro.
 \p
 \v 1 Ndokuti: Ndichakudai, Jehovha, simba rangu\x + Map. 116.1.\x*.
 \v 2 Jehovha idombo rangu, nenhare yangu, nemununuri wangu, Mwari wangu, ibwe rangu, wandichavimba maari, nhovo yangu, nerunyanga rweruponeso rwangu, shongwe yangu yakakwirira\x + VaHeb. 2.13.\x*.

--- a/Psalms/19/data
+++ b/Psalms/19/data
@@ -1,6 +1,6 @@
 \c 19
 \s Mabasa aMwari nemirairo yake
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Matenga anorondedzera kubwinya kwaMwari; uye muchadenga munoparidza basa remaoko ake\x + Gen.. 1.6. Map. 50.6. VaRom. 1.19,20. Job. 9.8.\x*.
 \v 2 Zuva rinodururira nhauro\x + Map. 145.7.\x* kuzuva, neusiku hunoratidza ruzivo\x + Job. 32.6,17.\x* kuusiku.

--- a/Psalms/20/data
+++ b/Psalms/20/data
@@ -1,6 +1,6 @@
 \c 20
 \s Munyengetero wekukumbira kukunda
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Jehovha ngaakupindure pazuva redambudziko; zita raMwari waJakove ngarikukwiridzire.
 \v 2 Ngaakutumire rubatsiro runobva panzvimbo tsvene\x + 2 Makor. 20.8. Map. 73.17. 74.7.\x*; uye akutsigire ari paZiyoni\x + Map. 128.5.\x*.

--- a/Psalms/21/data
+++ b/Psalms/21/data
@@ -1,6 +1,6 @@
 \c 21
 \s Kuvonga Mwari pakununurwa
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Mambo achafara musimba renyu, Jehovha; nemuruponeso rwenyu achafara zvikuru sei\x + Map. 9.14.\x*!
 \v 2 Makamupa chishuvo chemoyo wake, uye hamuna kunyima chikumbiro chemiromo yake\x + Map. 20.4,5.\x*. Sera.

--- a/Psalms/22/data
+++ b/Psalms/22/data
@@ -1,6 +1,6 @@
 \c 22
 \s Kuchema kwemunhu wakasiiwa naMwari
-\p Kumutungamiriri wekuimba; nenondo yemangwanani. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba; nenondo yemangwanani. Pisarema raDhavhidhi.
 \p
 \v 1 Mwari wangu, Mwari wangu, mandisiireiko\x + Mat. 27.46. Mako 15.34.\x*? Muri kure nekundibatsira, \add nepa\add*mashoko ekuvovora kwangu\x + Job. 3.24. Map. 32.3. Map. 38.8. VaHeb. 5.7.\x*?
 \v 2 Mwari wangu, ndinodana masikati, asi hamupinduri; nepausiku, asi handina kunyarara\x + Map. 88.1.\x*.

--- a/Psalms/23/data
+++ b/Psalms/23/data
@@ -1,6 +1,6 @@
 \c 23
 \s Jehovha mufudzi wangu
-\p Pisarema raDhavhidhi.
+\d Pisarema raDhavhidhi.
 \p
 \v 1 Jehovha mufudzi wangu\x + Isa. 40.11. Eze. 34.23. Joh. 10.11.\x*; handishaiwi\x + VaFir. 4.19.\x*.
 \v 2 Anondirarisa pamafuro manyoro\x + Eze. 34.14. Joh. 10.9.\x*; anondisesedza pamvura inozorodza\x + Map. 31.3. Isa. 40.11. 49.10. Zvak. 7.17.\x*.

--- a/Psalms/24/data
+++ b/Psalms/24/data
@@ -1,6 +1,6 @@
 \c 24
 \s Jehovha weumambo
-\p Pisarema raDhavhidhi.
+\d Pisarema raDhavhidhi.
 \p
 \v 1 Nyika ndeyaJehovha\x + Eki. 9.29. Eki. 19.5. Det. 10.14. Job. 41.11. Map. 50.12. 1 VaKori. 10.26,28.\x*, nekuzara kwayo, nyika nevagere mairi\x + Det. 33.16. Map. 50.12. 89.11. 96.11. 98.7.\x*.
 \v 2 Nokuti iye wakaiteya\x + Map. 104.5.\x* pamusoro pemakungwa, nekuisimbisa pamusoro penzizi\x + Map. 136.6. Gen.. 1.9. 2 Pet. 3.5.\x*.

--- a/Psalms/29/data
+++ b/Psalms/29/data
@@ -1,6 +1,6 @@
 \c 29
 \s Inzwi raJehovha
-\p Pisarema raDhavhidhi.
+\d Pisarema raDhavhidhi.
 \p
 \v 1 Ipai kuna Jehovha, imwi vanakomana vemasimba, ipai kuna Jehovha kudzo nesimba\x + 1 Makor. 16.28,29. Map. 96.7,8. Map. 68.34.\x*.
 \v 2 Ipai kuna Jehovha\x + 1 Makor. 16.28,29. Map. 96.7,8. Map. 68.34.\x* kudzo yezita rake\x + 1 Makor. 16.28,29. Map. 96.7,8. Map. 68.34.\x*; shumirai Jehovha mukunaka kweutsvene\x + 1 Makor. 16.29.\x*.

--- a/Psalms/3/data
+++ b/Psalms/3/data
@@ -1,6 +1,6 @@
 \c 3
 \s Munyengetero wekukumbira rubatsiro
-\p Pisarema raDhavhidhi paakatiza kubva pana Abhusaromu mwanakomana wake.
+\d Pisarema raDhavhidhi paakatiza kubva pana Abhusaromu mwanakomana wake.
 \p
 \v 1 Jehovha, vakawanda sei vadzivisi vangu\x + 2 Sam. 15.12. 16.15.\x*! Vazhinji vanondimukira\x + 2 Sam. 22.40.\x*.
 \v 2 Vazhinji vanoti pamusoro pemweya wangu: Hakuna ruponeso kwaari kubva kuna Mwari. Sera\x + 2 Sam. 16.8. Map. 71.11.\x*.

--- a/Psalms/30/data
+++ b/Psalms/30/data
@@ -1,6 +1,6 @@
 \c 30
 \s Rwiyo rwekuvonga
-\p Pisarema, rwiyo pakutsaurira Dhavhidhi imba.
+\d Pisarema, rwiyo pakutsaurira Dhavhidhi imba.
 \p
 \v 1 Ndichakukudzai, Jehovha, nokuti makandisimudza\x + Map. 107.32.\x*, uye hamuna kuita vavengi vangu vafare pamusoro pangu\x + Map. 35.19,24. Map. 13.4.\x*.
 \v 2 Jehovha, Mwari wangu, ndakachema kwamuri\x + Map. 88.13.\x*, uye mukandirapa\x + Map. 6.2.\x*.

--- a/Psalms/31/data
+++ b/Psalms/31/data
@@ -1,6 +1,6 @@
 \c 31
 \s Dhavhidhi anokumbira kubatsirwa, achivonga unyoro hwaJehovha
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Kwamuri Jehovha, ndinovimba\x + Map. 71.1-3. Map. 25.2.\x*; ndirege kutongonyadziswa\x + Map. 71.1-3. Map. 25.2.\x*; ndinunurei mukururama kwenyu\x + Map. 143.1.\x*.
 \v 2 Rerekerai nzeve yenyu kwandiri; kurumidzai kundinunura; ivai dombo rangu rakasimba\x + Map. 86.1.\x*, imba yenhare yakasimba yekundiponesa\x + 2 Sam. 22.2. Map. 18.2.\x*.

--- a/Psalms/36/data
+++ b/Psalms/36/data
@@ -1,6 +1,6 @@
 \c 36
 \s Kuipa kwewakaipa nekunaka kwaMwari
-\p Kumutungamiriri wekuimba. \add Pisarema\add* raDhavhidhi muranda waJehovha\x + Map. 18.\x*.
+\d Kumutungamiriri wekuimba. \add Pisarema\add* raDhavhidhi muranda waJehovha\x + Map. 18.\x*.
 \p
 \v 1 Nhaurwa yekupanduka kune wakaipa \add iri\add* mumoyo wangu: Hakuna kutya Mwari pamberi pemeso ake\x + VaRom. 3.18.\x*.
 \v 2 Nokuti anozvinyengera pameso ake\x + Det. 29.19. Map. 10.3. 49.18. Map. 5.9.\x*, uipi hwake kusvika hwawanikwa huchivengeka\x + 36.2,3,12. Mik. 2.1.\x*.

--- a/Psalms/38/data
+++ b/Psalms/38/data
@@ -1,6 +1,6 @@
 \c 38
 \s Munyengetero wemunhu anotambudzika
-\p Pisarema raDhavhidhi, rekuyeudzira.
+\d Pisarema raDhavhidhi, rekuyeudzira.
 \p
 \v 1 Jehovha, regai kunditsiura pakutsamwa kwenyu, kana kundiranga pakupfuta kwehasha dzenyu\x + Map. 6.1.\x*.
 \v 2 Nokuti miseve yenyu yakanyura mandiri\x + Job. 6.4.\x*, uye ruoko rwenyu rwunonyura pamusoro pangu\x + Map. 32.4.\x*.

--- a/Psalms/39/data
+++ b/Psalms/39/data
@@ -1,6 +1,6 @@
 \c 39
 \s Munyengetero pakutambudzika
-\p Kumutungamiriri wekuimba, kuna Jedhutuni. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba, kuna Jedhutuni. Pisarema raDhavhidhi.
 \p
 \v 1 Ndakati: Ndichachenjerera nzira dzangu\x + 1 Madz. 2.4. 2 Madz. 10.31.\x*, kuti ndirege kutadza nerurimi rwangu\x + Job. 2.10.\x*; ndichachengeta muromo wangu netomu, kana wakaipa achipo pamberi pangu\x + Map. 141.3. Jak. 3.2.\x*.
 \v 2 Ndaiva mbeveve \add ne\add*kunyarara\x + Map. 38.13. 39.9.\x*, ndakanyararira zvakanaka\x + Map. 28.1.\x*; uye kutambudzika kwangu kwakamutswa.

--- a/Psalms/4/data
+++ b/Psalms/4/data
@@ -1,6 +1,6 @@
 \c 4
 \s Mufaro nerugare zviri kuna Jehovha
-\p Kumutungamiriri wenziyo; nemitengeranwa; pisarema raDhavhidhi.
+\d Kumutungamiriri wenziyo; nemitengeranwa; pisarema raDhavhidhi.
 \p
 \v 1 Ndipindurei pakudana kwangu, Mwari wekururama kwangu; pakumanikidzwa makapa \add nzvimbo\add* yakafaranuka kwandiri. Ivai nengoni kwandiri, mugonzwa munyengetero wangu\x + Job. 36.16. Map. 66.14.\x*.
 \v 2 Imwi vanakomana vevanhu, kusvika rinhi \add muchishandura\add* rukudzo rwangu kuva chinyadzo, muchida zvisina maturo, muchitsvaga nhema? Sera\x + Map. 5.6.\x*.

--- a/Psalms/40/data
+++ b/Psalms/40/data
@@ -1,6 +1,6 @@
 \c 40
 \s Mufaro wemunhu anotenda kuna Jehovha
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Ndakarindira-rindira Jehovha\x + Map. 37.7. Map. 27.14.\x*; uye wakarerekera kwandiri, ndokunzwa kuchema kwangu\x + Map. 39.12.\x*.
 \v 2 Akandinyururawo pagomba rekuparadzwa, mudziva\x + Map. 69.14.\x* rematope\x + Map. 69.2.\x*, ndokuisa tsoka dzangu padombo\x + Map. 27.5.\x*, akasimbisa nhanho dzangu\x + Map. 37.23.\x*.

--- a/Psalms/41/data
+++ b/Psalms/41/data
@@ -1,6 +1,6 @@
 \c 41
 \s Munyengetero pakurwara
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Wakaropafadzwa anorangarira murombo\x + Zvir. 14.21. Mat. 5.7.\x*; Jehovha achamununura nezuva rechakaipa\x + Mab. 12.11.\x*.
 \v 2 Jehovha achamuchengetedza, nekumuraramisa; achava wakaropafadzwa panyika; uye hamungamukumikidzi kuchido chevavengi vake.

--- a/Psalms/42/data
+++ b/Psalms/42/data
@@ -1,6 +1,6 @@
 \c 42
 \s Chishuvo chemutapwa kushumira Jehovha patembere
-\p Kumutungamiriri wekuimba. Maskiri; kwevanakomana vaKora.
+\d Kumutungamiriri wekuimba. Maskiri; kwevanakomana vaKora.
 \p
 \v 1 Senondo inotakwairira hova dzemvura, saizvozvo mweya wangu unokutakwairirai, Mwari\x + Map. 18.15.\x*.
 \v 2 Mweya wangu une nyota kuna Mwari\x + Map. 63.1. Map. 84.2. 143.6.\x*, kuna Mwari mupenyu\x + Map. 84.2. Josh. 3.10. Mat. 26.63. Jer. 10.10. 23.36. Dhan. 6.26. VaRom. 9.26. 2 VaKori. 3.3. 6.16. 1 Tim. 3.15. 4.10. 6.17. VaHeb. 3.12. 9.14. 10.31. 12.22 Zvak. 7.2.\x*; ndichasvika rinhi ndionekwe pamberi pechiso chaMwari\x + Map. 84.7.\x*?

--- a/Psalms/44/data
+++ b/Psalms/44/data
@@ -1,6 +1,6 @@
 \c 44
 \s Vanhu vaMwari vanochema kwaari pakutambudzika kwavo
-\p Kumutungamiriri wekuimba. Wevanakomana VaKora. Masikiri.
+\d Kumutungamiriri wekuimba. Wevanakomana VaKora. Masikiri.
 \p
 \v 1 Mwari, takanzwa nenzeve dzedu; madzibaba edu akatirondedzera\x + Vato. 6.13. Map. 78.3. Eki. 12.26.\x*; basa ramakabata pamazuva avo, pamazuva ekare\x + Isa. 23.7. Map. 77.5.\x*.
 \v 2 Imwi neruoko rwenyu makadzinga vahedheni panhaka\x + Josh. 3.10. 2 Makor. 20.7. Det. 7.1. Vato. 6.9. Neh. 9.24. Map. 78.55. 80.8. Mab. 7.45. 13.19.\x*, ndokuvasima ivo\x + Eki. 15.17. Map. 80.8.\x*; makatambudza marudzi, asi makavaparadzira\x + Gen.. 43.14.\x*.

--- a/Psalms/45/data
+++ b/Psalms/45/data
@@ -1,6 +1,6 @@
 \c 45
 \s Rwiyo pamutambo waMambo Mukuru
-\p Kumutungamiriri wekuimba; paShoshanimi. \add Pisarema\add* revanakomana vaKora. Masikiri. Rwiyo rwerudo ruzhinji.
+\d Kumutungamiriri wekuimba; paShoshanimi. \add Pisarema\add* revanakomana vaKora. Masikiri. Rwiyo rwerudo ruzhinji.
 \p
 \v 1 Moyo wangu unotutuma nyaya yakanaka; ndinotaura zvinhu zvandakaitira mambo; rurimi rwangu ipeni\x + Job. 19.24. Jer. 8.8. 17.1.\x* yemunyori anokurumidza\x + Ezi. 7.6.\x*.
 \p

--- a/Psalms/46/data
+++ b/Psalms/46/data
@@ -1,6 +1,6 @@
 \c 46
 \s Mwari utiziro hwedu
-\p Kumutungamiriri wekuimba. \add Pisarema\add* revanakomana vaKora; rwiyo rweAramoti.
+\d Kumutungamiriri wekuimba. \add Pisarema\add* revanakomana vaKora; rwiyo rweAramoti.
 \p
 \v 1 Mwari utiziro hwedu nesimba\x + Map. 14.6.\x*, wakaratidzwa kuva rubatsiro rukuru\x + Det. 4.7.\x* pamatambudziko\x + Map. 9.9.\x*.
 \v 2 Naizvozvo hatingatyi pakushanduka kwenyika, kunyange makomo akasudzunukira mukati memakungwa.

--- a/Psalms/47/data
+++ b/Psalms/47/data
@@ -1,6 +1,6 @@
 \c 47
 \s Marudzi ese ngaarumbidze Jehovha
-\p Kumutungamiriri wekuimba. Pisarema revanakomana vaKora.
+\d Kumutungamiriri wekuimba. Pisarema revanakomana vaKora.
 \p
 \v 1 Uchirai, imwi marudzi ese\x + Nah. 3.19. 2 Madz. 11.12. Isa. 55.12.\x*! Pururudzai kuna Mwari neinzwi remufaro\x + Map. 95.1.\x*.
 \v 2 Nokuti Jehovha Wekumusoro-soro anotyisa; ndiMambo mukuru pamusoro penyika yose\x + Map. 66.2,5,68. 5.76. 7.12. 89.7. Mara. 1.14. Det. 7.21.\x*.

--- a/Psalms/48/data
+++ b/Psalms/48/data
@@ -1,6 +1,6 @@
 \c 48
 \s Ziyoni guta raMambo Mukuru
-\p Rwiyo. Pisarema revanakomana vaKora.
+\d Rwiyo. Pisarema revanakomana vaKora.
 \p
 \v 1 Mukuru Jehovha, uye ndewekurumbidzwa kukuru\x + 1 Makor. 16.25. Map. 96.4. 145.3. Map. 76.1. 113.3. 147.5. 2 Sam. 7.22.\x*, muguta raMwari wedu\x + Map. 46.4.\x*, gomo rake dzvene\x + Map. 87.1. Isa. 2.3. Zek. 8.3. Map. 2.6.\x*.
 \v 2 Rakanaka pakukwirira\x + Map. 50.2.\x*, mufaro wenyika yose igomo reZiyoni\x + Marir. 2.15.\x*, \add pa\add*mativi ekumaodzanyemba\x + Isa. 14.13. Eze. 38.6,15. 39.2.\x*, guta raMambo mukuru\x + Mat. 5.35. Map. 87.3. 132.13.\x*.

--- a/Psalms/49/data
+++ b/Psalms/49/data
@@ -1,6 +1,6 @@
 \c 49
 \s Zvese zvepanyika zvinopfuura
-\p Kumutungamiriri wekuimba. Pisarema revanakomana vaKora.
+\d Kumutungamiriri wekuimba. Pisarema revanakomana vaKora.
 \p
 \v 1 Inzwai chinhu ichi, vanhu vose\x + Map. 78.1. Job. 11.17.\x*. Ipai nzeve, vagari vese vepanyika\x + Map. 78.1. Job. 11.17.\x*.
 \v 2 Zvese vakaderera nevakakwirira, mufumi nemurombo pamwe chete\x + Map. 62.9.\x*.

--- a/Psalms/5/data
+++ b/Psalms/5/data
@@ -1,6 +1,6 @@
 \c 5
 \s Dhavhidhi anokumbira kuti afambiswe zvakanaka pakati pevavengi vake
-\p Kumutungamiriri wekuimba; nenehiroti. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba; nenehiroti. Pisarema raDhavhidhi.
 \p
 \v 1 Ipai nzeve kumashoko angu, Jehovha, mucherekedze kuzvidya moyo kwangu\x + Map. 39.3.\x*.
 \v 2 Teererai kuinzwi rekuchema kwangu, mambo wangu naMwari wangu\x + Map. 84.3.\x*; nokuti kwamuri ndinonyengetera\x + Map. 65.2.\x*.

--- a/Psalms/50/data
+++ b/Psalms/50/data
@@ -1,6 +1,6 @@
 \c 50
 \s Kushumira Mwari kwechokwadi
-\p Pisarema raAsafi.
+\d Pisarema raAsafi.
 \p
 \v 1 Mwari wevamwari, Jehovha, wakataura\x + Neh. 9.32. Isa. 9.6. Jer. 32.18.\x*, nekudana nyika kubva pakubuda kwezuva kusvika pakuvira kwaro\x + Map. 113.3.\x*.
 \v 2 Ari muZiyoni, kuperera kwekunaka\x + Marir. 2.15. Map. 48.2.\x*, Mwari wakapenya\x + Det. 33.2. Job. 3.4. 10.3,22. Map. 80.1. 94.1.\x*.

--- a/Psalms/51/data
+++ b/Psalms/51/data
@@ -1,6 +1,6 @@
 \c 51
 \s Rwiyo rwekuchema zvivi
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi, Natani muporofita paakasvika kwaari, shure kwekunge apinda kuna Bhati-Shebha.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi, Natani muporofita paakasvika kwaari, shure kwekunge apinda kuna Bhati-Shebha.
 \p
 \v 1 Ndinzwirei tsitsi, Mwari\x + Map. 25.7. Map. 106.45. Map. 4.1.\x*, zvichienderana nerudo rweunyoro hwenyu\x + Map. 25.7. Map. 106.45. Map. 4.1.\x*; zvichienderana neuwandu hwengoni dzenyu, dzimai zvitadzo zvangu\x + 51.9. Isa. 43.25. 44.22. Mab. 3.19. VaKoro. 2.14.\x*.
 \v 2 Ndisukei kwazvo kubva pauipi hwangu, uye ndinatsei kubva pachivi changu\x + 51.7. Zvak. 1.5. Mab. 22.16.\x*.

--- a/Psalms/52/data
+++ b/Psalms/52/data
@@ -1,6 +1,6 @@
 \c 52
 \s Kushaya maturo kwekuzvikudza nekuita zvakaipa
-\p Kumutungamiriri wekuimba. Masikiri. \add Pisarema\add* raDhavhidhi. Dhoegi muEdhomu paakauya achiudza Sauro, ndokuti kwaari: Dhavhidhi wasvika paimba yaAhimereki.
+\d Kumutungamiriri wekuimba. Masikiri. \add Pisarema\add* raDhavhidhi. Dhoegi muEdhomu paakauya achiudza Sauro, ndokuti kwaari: Dhavhidhi wasvika paimba yaAhimereki.
 \p
 \v 1 Unozvirumbidzirei nezvakaipa, mhare? Tsitsi dzaMwari \add dziripo\add* mazuva ose\x + Map. 120.4. 1 Sam. 21.7.\x*.
 \v 2 Rurimi rwako\x + Map. 50.19.\x* runoronga kuparadza kukuru\x + 52.7. Job. 6.30. Map. 5.9. 38.12. 55.11. 57.1. 91.3. 94.20.\x*, sechisvo chinopinza\x + Map. 57.4. 140.3.\x*, rwunoita unyengeri\x + Map. 101.7.\x*.

--- a/Psalms/53/data
+++ b/Psalms/53/data
@@ -1,6 +1,6 @@
 \c 53
 \s Vanhu vese vakashata
-\p Kumutungamiriri wekuimba. NeMaharati. Masikiri. \add Pisarema\add* raDhavhidhi.
+\d Kumutungamiriri wekuimba. NeMaharati. Masikiri. \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Benzi rakati mumoyo maro: Hakuna Mwari\x + Map. 14.1-7.\x*. Vakaodza, vakaita uipi hunonyangadza; hakuna anoita zvakanaka\x + VaRom. 3.10-12.\x*.
 \v 2 Mwari wakatarisa pasi ari kumatenga pamusoro pevanakomana vevanhu, kuona kana pane anonzwisisa, anotsvaka Mwari\x + VaRom. 3.10-12.\x*.

--- a/Psalms/54/data
+++ b/Psalms/54/data
@@ -1,6 +1,6 @@
 \c 54
 \s Dhavhidhi anonyengetera kuti anunurwe pavavengi vake
-\p Kumutungamiriri wekuimba; nemitengeranwa. Masikiri. \add Pisarema\add* raDhavhidhi. VaZifi pavakauya vakati kuna Sauro: Dhavhidhi haazinovanda kwatiri here?
+\d Kumutungamiriri wekuimba; nemitengeranwa. Masikiri. \add Pisarema\add* raDhavhidhi. VaZifi pavakauya vakati kuna Sauro: Dhavhidhi haazinovanda kwatiri here?
 \p
 \v 1 Mwari, ndiponesei nezita renyu, uye nditongei nesimba renyu.
 \v 2 Mwari, inzwai munyengetero wangu; ipai nzeve pamashoko emuromo wangu\x + Map. 55.1.\x*.

--- a/Psalms/55/data
+++ b/Psalms/55/data
@@ -1,6 +1,6 @@
 \c 55
 \s Dhavhidhi anochema pakutambudzika kwake
-\p Kumutungamiriri wekuimba; nemitengeranwa. Masikiri. \add Pisarema\add* raDhavhidhi.
+\d Kumutungamiriri wekuimba; nemitengeranwa. Masikiri. \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Ipai nzeve\x + Map. 54.2. 86.6. Map. 61.1. 66.19.\x*, Mwari, kumunyengetero wangu\x + Map. 6.9.\x*, uye musazvivanza pamukumbiro wangu\x + Map. 6.9.\x*.
 \v 2 Teererai kwandiri\x + Map. 54.2. 86.6. Map. 61.1. 66.19.\x*, uye ndipindurei\x + Map. 3.4.\x*. Ndinodzungaira mukuchema kwangu\x + Map. 64.1. 55.17.\x*, ndinoita rukunga\x + Mik. 2.12.\x*;

--- a/Psalms/56/data
+++ b/Psalms/56/data
@@ -1,6 +1,6 @@
 \c 56
 \s Kuvimba naMwari
-\p Kumutungamiri wekuimba; neJonati-Eremi-Rekokimi. Mikitami yaDhavhidhi, VaFirisitia pavakamutora muGati.
+\d Kumutungamiri wekuimba; neJonati-Eremi-Rekokimi. Mikitami yaDhavhidhi, VaFirisitia pavakamutora muGati.
 \p
 \v 1 Ndinzwirei tsitsi, Mwari\x + Map. 4.1.\x*, nokuti munhu anondimedza\x + Map. 57.3. Map. 21.9. 124.3.\x*; zuva rese achirwa anondimanikidza.
 \v 2 Vavengi vangu vano\add ndi\add*medza zuva rese\x + Map. 57.3. Map. 21.9. 124.3.\x*; nokuti vanondirwisa nekuzvikudza\x + Map. 92.8. Map. 83.18.\x* vazhinji.

--- a/Psalms/57/data
+++ b/Psalms/57/data
@@ -1,6 +1,6 @@
 \c 57
 \s Munyengetero wekukumbira kununurwa
-\p Kumutungamiriri wekuimba. Aritasheti. Mikitani yaDhavhidhi. Pakutiza kwake Sauro pabako.
+\d Kumutungamiriri wekuimba. Aritasheti. Mikitani yaDhavhidhi. Pakutiza kwake Sauro pabako.
 \p
 \v 1 Ndinzwirei tsitsi, Mwari, ndinzwirei tsitsi\x + Map. 4.1.\x*; nokuti mweya wangu unovimba nemwi\x + Map. 25.2.\x*; uye ndichatizira kumumvuri wemapapiro enyu\x + Rut. 2.12.\x*, kusvika\x + Isa. 26.20.\x* mharadzo dzapfuura\x + Map. 52.2.\x*.
 \v 2 Ndichachema kuna Mwari Wekumusoro-soro, kuna Mwari anondizadzisira\x + Map. 138.8.\x*.

--- a/Psalms/58/data
+++ b/Psalms/58/data
@@ -1,6 +1,6 @@
 \c 58
 \s Kukumbira kuti vakaipa vaparadzwe
-\p Kumutungamiriri wekuimba. Aritasheti. Mikitani yaDhavhidhi.
+\d Kumutungamiriri wekuimba. Aritasheti. Mikitani yaDhavhidhi.
 \p
 \v 1 Zvirokwazvo munotaura zvakarurama here, imwi vatongi? Munotonga zvakarurama here, imwi vanakomana vevanhu\x + Map. 17.2.\x*?
 \v 2 Hongu, mumoyo munoita zvakaipa; munoyerera manikidzo yemaoko enyu panyika\x + Map. 78.50. Zvir. 4.26. 5.6,21. Isa. 26.7. Map. 94.20. Isa. 10.1.\x*.

--- a/Psalms/59/data
+++ b/Psalms/59/data
@@ -1,6 +1,6 @@
 \c 59
 \s Munyengetero wekukumbira kununurwa pavavengi
-\p Kumutungamiriri wekuimba. Aritasheti. Mikitani yaDhavhidhi. Sauro paakatuma, uye vakarinda imba kumuuraya.
+\d Kumutungamiriri wekuimba. Aritasheti. Mikitani yaDhavhidhi. Sauro paakatuma, uye vakarinda imba kumuuraya.
 \p
 \v 1 Ndinunurei pavavengi vangu, Mwari wangu\x + Map. 143.9. 2 Sam. 22.49.\x*; ndiise pakakwirira kubva pane vanondimukira\x + Map. 143.9. 2 Sam. 22.49.\x*\x + Map. 17.7. 139.21.\x*.
 \v 2 Ndinunurei kubva kuvaiti vezvakaipa\x + Map. 94.4.\x*, uye ndiponesei pavanhu veropa\x + Map. 5.6.\x*.

--- a/Psalms/6/data
+++ b/Psalms/6/data
@@ -1,6 +1,6 @@
 \c 6
 \s Dhavhidhi anochema zvivi zvake
-\p Kumutungamiriri wenziyo; nemitengeranwa, neShiminiti. Pisarema raDhavhidhi.
+\d Kumutungamiriri wenziyo; nemitengeranwa, neShiminiti. Pisarema raDhavhidhi.
 \p
 \v 1 Jehovha, musanditsiura pakutsamwa kwenyu\x + Map. 38.1.\x*, musandiranga nehasha dzenyu\x + Jer. 10.24. Jer. 30.11. 46.28.\x*.
 \v 2 Ndinzwirei tsitsi, Jehovha, nokuti handina simba\x + Map. 4.1.\x*; ndiporesei, Jehovha, nokuti mapfupa angu\x + Map. 30.2. 41.4. 103.3. 107.20. 147.3. Jer. 17.14. 30.17. 33.6. Hos. 6.1.\x* anoshungurudzika\x + Map. 2.5.\x*.

--- a/Psalms/60/data
+++ b/Psalms/60/data
@@ -1,6 +1,6 @@
 \c 60
 \s Munyengetero wekukumbira kubatsirwa nekukunda
-\p Kumutungamiriri wekuimba; paShushani Edhuti. Mikitami yaDhavhidhi, kudzidzisa; paairwa naArami-Naharaimi naArami-Zobha, Joabhu paakadzoka akarova VaEdhomu paMupata weMunyu, zvuru gumi nezviviri.
+\d Kumutungamiriri wekuimba; paShushani Edhuti. Mikitami yaDhavhidhi, kudzidzisa; paairwa naArami-Naharaimi naArami-Zobha, Joabhu paakadzoka akarova VaEdhomu paMupata weMunyu, zvuru gumi nezviviri.
 \p
 \v 1 Mwari, manga makatirasa, makatiputikira\x + 60.10. Map. 44.9.\x*; makatsamwa; dzokerai kwatiri\x + Map. 80.3.\x*.
 \v 2 Makabvundisa nyika; makaitsemura; poresai mitswe yayo; nokuti inozununguka\x + 2 Makor. 7.14.\x*.

--- a/Psalms/61/data
+++ b/Psalms/61/data
@@ -1,6 +1,6 @@
 \c 61
 \s Dhavhidhi anovimba naMwari pakutambudzika kwake
-\p Kumutungamiriri wekuimba. Nemutengeranwa. \add Pisarema\add* raDhavhidhi.
+\d Kumutungamiriri wekuimba. Nemutengeranwa. \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Inzwai, Mwari, kuchema kwangu; teererai kumunyengetero wangu\x + Map. 55.1,2.\x*.
 \p

--- a/Psalms/62/data
+++ b/Psalms/62/data
@@ -1,6 +1,6 @@
 \c 62
 \s Kunyarara kwemweya wemunhu anovimba naMwari
-\p Kumutungamiriri wekuimba; neJedhutuni. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba; neJedhutuni. Pisarema raDhavhidhi.
 \p
 \v 1 Zvirokwazvo, mweya wangu unorindira Mwari murunyararo; ruponeso rwangu rwunobva kwaari\x + Map. 33.20.\x*.
 \v 2 Ndiye oga dombo rangu, neruponeso rwangu\x + 62.6. Eki. 15.2. Map. 38.22.\x*, shongwe yangu; handingazununguswi zvikuru\x + Map. 10.6.\x*.

--- a/Psalms/63/data
+++ b/Psalms/63/data
@@ -1,6 +1,6 @@
 \c 63
 \s Dhavhidhi anoshuva Jehovha
-\p Pisarema raDhavhidhi, paaiva murenje raJudha.
+\d Pisarema raDhavhidhi, paaiva murenje raJudha.
 \p
 \v 1 Mwari, muri Mwari wangu, ndichakutsvakai mangwanani\x + Map. 78.34. Zvir. 7.15. Isa. 26.9. Job. 7.21.\x*; mweya wangu unenyota kwamuri\x + Map. 84.2. Map. 42.2.\x*, nyama yangu inokushuvai\x + Map. 84.2. Map. 42.2.\x*, panyika yakaoma, yakasakara, isina mvura\x + Map. 78.17. 107.35. Map. 105.41.\x*.
 \v 2 Naizvozvo ndakatarira kwamuri panzvimbo tsvene, kuti ndione simba renyu nekubwinya kwenyu\x + 1 Makor. 16.11. Map. 78.61. 105.4. 132.8. Map. 27.4.\x*.

--- a/Psalms/64/data
+++ b/Psalms/64/data
@@ -1,6 +1,6 @@
 \c 64
 \s Munyengetero wekukumbira kudzivirirwa pavavengi
-\p Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema raDhavhidhi.
 \p
 \v 1 Inzwai inzwi rangu, Mwari, pachichemo changu; chengetedzai upenyu hwangu pakutya muvengi\x + Map. 55.2. Job. 15.4.\x*.
 \v 2 Ndivanzei pazano rakavanda revakaipa\x + Job. 29.4. Map. 55.14.\x*, pabope\x + Job. 29.4. Map. 55.14.\x* revaiti vezvakaipa\x + Map. 94.4.\x*,

--- a/Psalms/65/data
+++ b/Psalms/65/data
@@ -1,6 +1,6 @@
 \c 65
 \s Dhavhidhi anorumbidza Mwari
-\p Kumutungamiriri wekuimba. Pisarema. Rwiyo rwaDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema. Rwiyo rwaDhavhidhi.
 \p
 \v 1 Kumirira murunyararo irumbidzo kwamuri, Mwari, paZiyoni; uye mhiko dzichazadziswa mamuri\x + Map. 132.2. Map. 50.14.\x*.
 \v 2 Munzwi wemunyengetero\x + 2 Madz. 19.20. Map. 5.2.\x*, nyama yose ichauya kwamuri\x + Map. 86.9. Isa. 66.23.\x*.

--- a/Psalms/66/data
+++ b/Psalms/66/data
@@ -1,6 +1,6 @@
 \c 66
 \s Kurumbidza Mwari nekumuvonga
-\p Kumutungamiriri wekuimba. Rwiyo. Pisarema.
+\d Kumutungamiriri wekuimba. Rwiyo. Pisarema.
 \p
 \v 1 Pururudzai kuna Mwari, imwi nyika yose\x + Map. 95.1.\x*.
 \v 2 Imbirai kubwinya kwezita rake; muite rukudzo rwake rwuve nekubwinya\x + Isa. 42.12.\x*.

--- a/Psalms/67/data
+++ b/Psalms/67/data
@@ -1,6 +1,6 @@
 \c 67
 \s Rwiyo rwekuvonga
-\p Kumutungamiriri wekuimba; nemitengeranwa. Pisarema, rwiyo.
+\d Kumutungamiriri wekuimba; nemitengeranwa. Pisarema, rwiyo.
 \p
 \v 1 Mwari ngaave tsitsi kwatiri, uye atiropafadze\x + Num.. 6.25,24.\x*; ngaavhenekerese chiso chake patiri. Sera\x + Num.. 6.25. Job. 33.26. Map. 4.6. 31.16.\x*.
 \v 2 Kuti nzira yenyu izikanwe panyika, ruponeso rwenyu pakati pemarudzi ose\x + Ruk. 2.30,31. Tit. 2.11.\x*.

--- a/Psalms/68/data
+++ b/Psalms/68/data
@@ -1,6 +1,6 @@
 \c 68
 \s Rwiyo rwekurumbidza Mwari
-\p Kumutungamiriri wekuimba. Pisarema, rwiyo rwaDhavhidhi.
+\d Kumutungamiriri wekuimba. Pisarema, rwiyo rwaDhavhidhi.
 \p
 \v 1 Mwari ngaasimuke; vavengi\x + Num.. 10.35. Map. 24. 132.8. Isa. 33.3.\x* vake ngavaparadzirwe\x + Map. 89.10. 92.9.\x*; uye vanomuvenga ngavatize pamberi pake.
 \v 2 Sekupepereswa kweutsi, \add va\add*peperesei\x + Map. 37.20. Isa. 9.18. Hos. 13.3.\x*; sekunyunguduswa kwenamo pamberi pemoto, vakaipa ngavaparare pamberi paMwari\x + Map. 22.14. 97.5. Mik. 1.4.\x*.

--- a/Psalms/69/data
+++ b/Psalms/69/data
@@ -1,6 +1,6 @@
 \c 69
 \s Munyengetero weanotambudzika
-\p Kumutungamiriri wekuimba; neShoshanimi. \add Pisarema\add* raDhavhidhi.
+\d Kumutungamiriri wekuimba; neShoshanimi. \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Ndiponesei, Mwari, nokuti mvura yasvika\x + 69.2,14,15. Job. 22.11.\x* kumweya\x + Jona 2.5.\x*.
 \v 2 Ndinonyura munhope yakadzika, pasina kumira; ndapinda\x + Map. 40.2.\x*\x + 69.2,14,15. Job. 22.11.\x* munzvimbo dzakadzika dzemvura, mafashame\x + 69.15. Vato. 12.6.\x* paanondifukidza\x + Map. 124.4. 2 Makor. 32.4.\x*.

--- a/Psalms/7/data
+++ b/Psalms/7/data
@@ -1,6 +1,6 @@
 \c 7
 \s Dhavhidhi anokumbira kuti Jehovha amururamisire
-\p Shigayoni yaDhavhidhi yaakaimbira Jehovha pamashoko aKushi muBhenjamini.
+\d Shigayoni yaDhavhidhi yaakaimbira Jehovha pamashoko aKushi muBhenjamini.
 \p
 \v 1 Jehovha Mwari wangu, ndinovimba nemwi\x + Map. 2.12.\x*; ndiponesei kune vese vanonditeverera, mundinunure\x + Map. 31.15.\x*.
 \v 2 Zvimwe abvambure mweya wangu seshumba, abvamburanye pasina anonunura\x + Job. 10.16.\x*.

--- a/Psalms/70/data
+++ b/Psalms/70/data
@@ -1,6 +1,6 @@
 \c 70
 \s Dhavhidhi anokumbira kuti Jehovha amurwire
-\p Kumutungamiriri wekuimba. \add Pisarema\add* raDhavhidhi. Kurangaridza.
+\d Kumutungamiriri wekuimba. \add Pisarema\add* raDhavhidhi. Kurangaridza.
 \p
 \v 1 Mwari, kurumidzai, Jehovha, kundinunura, kurubatsiro rwangu\x + Map. 40.13-17.\x*.
 \v 2 Ngavanyadziswe vazvidzwe avo vanotsvaka mweya wangu; ngavadzoserwe shure vanyadziswe\x + Map. 40.14.\x* ivo vanofarira dambudziko rangu\x + Map. 40.14.\x*.

--- a/Psalms/73/data
+++ b/Psalms/73/data
@@ -1,6 +1,6 @@
 \c 73
 \s Kutambudzika kwevakaipa
-\p Pisarema raAsafi.
+\d Pisarema raAsafi.
 \p
 \v 1 Zvirokwazvo Mwari wakanaka kuna Israeri, kune vakachena pamoyo\x + Joh. 1.47. VaRom. 9.6.\x*.
 \v 2 Asi kana ndiri ini, tsoka dzangu dzakapotsa dzaenda, nhanho dzangu dzakapotsa dzatedzemuka\x + Num.. 20.17.\x*.

--- a/Psalms/74/data
+++ b/Psalms/74/data
@@ -1,6 +1,6 @@
 \c 74
 \s Kukumbira kuti Mwari abatsire vanhu vake
-\p Masikiri\x + Map. 32.0\x* yaAsafi.
+\d Masikiri\x + Map. 32.0\x* yaAsafi.
 \p
 \v 1 Mwari, sei maka\add ti\add*rasa nekusingaperi? Hasha dzenyu dzinopfungairi\add rei\add* makwai emafuro enyu?
 \v 2 Rangarirai ungano yenyu \add ya\add*makatenga kare, tsvimbo yenhaka yenyu \add ya\add*makadzikunura; gomo iri reZiyoni makagara mariri.

--- a/Psalms/75/data
+++ b/Psalms/75/data
@@ -1,6 +1,6 @@
 \c 75
 \s Mwari ndiye mutongi
-\p Kumutungamiriri wekuimba. Aritasheti. Pisarema raAsafi. Rwiyo.
+\d Kumutungamiriri wekuimba. Aritasheti. Pisarema raAsafi. Rwiyo.
 \p
 \v 1 Tinopa kuvonga kwamuri, Mwari; tinopa kuvonga kuti zita renyu riri pedo; vanorondedzera mabasa enyu anoshamisa\x + Det. 4.7.\x*.
 \v 2 Kana ndichigamuchira nguva yakatarwa\x + Map. 46.10.\x*, ini ndichatonga zvakarurama\x + Map. 17.2.\x*.

--- a/Psalms/76/data
+++ b/Psalms/76/data
@@ -1,5 +1,6 @@
 \c 76
-\p Kumutungamiriri wekuimba; nemitengeranwa. Pisarema raAsafi. Rwiyo.
+\d Kumutungamiriri wekuimba; nemitengeranwa. Pisarema raAsafi. Rwiyo.
+\p
 \v 1 Mwari anozikanwa kwaJudha; zita rake iguru kwaIsraeri\x + Map. 48.1,3.\x*.
 \v 2 PaSaremiwo\x + Gen.. 14.18. VaHeb. 7.1,2.\x* pane dumbu\x + Map. 27.5. Marir. 2.6.\x* rake, nenzvimbo yake yekugara paZiyoni.
 \v 3 Ipapo anovhuna\x + Map. 46.9.\x* miseve inopfuta yeuta\x + Map. 78.48. Det. 32.24.\x*, nhovo, nemunondo, nehondo. Sera.

--- a/Psalms/77/data
+++ b/Psalms/77/data
@@ -1,6 +1,6 @@
 \c 77
 \s Kusimbiswa kunobva pakurangarira mabasa ekare aMwari
-\p Kumutungamiriri wekuimba. NeJedhutuni. Pisarema raAsafi.
+\d Kumutungamiriri wekuimba. NeJedhutuni. Pisarema raAsafi.
 \p
 \v 1 Inzwi rangu riri kuna Mwari, uye ndinochema; inzwi rangu riri kuna Mwari, iye ndokupa nzeve kwandiri\x + Map. 142.1. Map. 3.4.\x*.
 \v 2 Pazuva rekutambudzika kwangu ndakatsvaka Ishe\x + Map. 86.7. Map. 20.1. 50.15.\x*. Ruoko rwangu rwaiva rwakatandavadzwa usiku, uye harwuna kuneta\x + Map. 63.6. Isa. 26.9. Map. 88.1.\x*; mweya wangu wakaramba kunyaradzwa\x + Gen.. 37.35.\x*.

--- a/Psalms/78/data
+++ b/Psalms/78/data
@@ -1,6 +1,6 @@
 \c 78
 \s Rangarirai zvamakaitirwa
-\p Masikiri yaAsafi.
+\d Masikiri yaAsafi.
 \p
 \v 1 Ipai nzeve, vanhu vangu, \add ku\add*murau wangu; rerekerai nzeve yenyu kumashoko emuromo wangu\x + Isa. 51.4. Map. 49.1. Map. 105. 106.\x*.
 \v 2 Ndichashamisa muromo wangu\x + Map. 49.4. Mat. 5.2. Mat. 13.35.\x* nemufananidzo\x + Num.. 21.27. Zvir. 1.1.\x*; ndichabudisa\x + Map. 145.7.\x* zvakavanzika zvekare\x + Zvir. 1.6. Vato. 14.12.\x*,

--- a/Psalms/79/data
+++ b/Psalms/79/data
@@ -1,6 +1,6 @@
 \c 79
 \s Kukumbira Mwari kuti abatsire vanhu vake
-\p Pisarema raAsafi.
+\d Pisarema raAsafi.
 \p
 \v 1 Mwari, vahedheni\x + Marir. 1.10.\x* vapinda panhaka yenyu\x + Map. 74.2.\x*; vakasvibisa tembere yenyu tsvene\x + Map. 5.7. Map. 74.7.\x*; Jerusarema vakariita rive mirwi\x + Mik. 3.12. Jer. 26.18. 2 Madz. 25.9,10. 2 Makor. 36.19. Map. 102.14. 137.3.\x*.
 \v 2 Zvitunha zvevaranda venyu vakapa shiri dzematenga kuva zvekudya\x + Det. 28.26. Jer. 15.3. 19.7.\x*, nyama yevatsvene venyu\x + Map. 50.5.\x* kuzvikara zvenyika\x + Map. 74.19. Map. 50.10.\x*.

--- a/Psalms/8/data
+++ b/Psalms/8/data
@@ -1,6 +1,6 @@
 \c 8
 \s Kukudzwa kwemunhu naJehovha
-\p Kumutungamiriri wekuimba; neGititi. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba; neGititi. Pisarema raDhavhidhi.
 \p
 \v 1 Jehovha, Ishe wedu, rinobwinya sei zita renyu panyika yese\x + Map. 148.13. Isa. 12.4.\x*! Imwi makaisa kubwinya kwenyu kumusoro kumatenga\x + Map. 113.4.\x*.
 \p

--- a/Psalms/80/data
+++ b/Psalms/80/data
@@ -1,6 +1,6 @@
 \c 80
 \s Munyengetero wekubatsirwa kwaIsraeri
-\p Kumutungamiriri wekuimba. NeShoshanimi-Eduti. Pisarema raAsafi.
+\d Kumutungamiriri wekuimba. NeShoshanimi-Eduti. Pisarema raAsafi.
 \p
 \v 1 Ipai nzeve, mufudzi waIsraeri, imwi munotungamirira Josefa\x + Map. 81.5.\x* seboka\x + Gen.. 48.15. 49.24. Map. 77.20. Map. 95.7.\x*, mugere \add pa\add*makerubhi*\x + Map. 99.1. Eki. 25.22.\x*, penyai\x + Map. 50.2.\x*!
 \v 2 Mutsai simba renyu pamberi paEfuremu naBhenjamini naManase\x + Num.. 2.18-23.\x*, muuye kuva ruponeso rwedu\x + Map. 35.23.\x*.

--- a/Psalms/81/data
+++ b/Psalms/81/data
@@ -1,6 +1,6 @@
 \c 81
 \s Kusateerera kwaIsraeri
-\p Kumutungamiriri wekuimba. NeGititi. RaAsafi.
+\d Kumutungamiriri wekuimba. NeGititi. RaAsafi.
 \p
 \v 1 Imbirai kwazvo Mwari, simba redu\x + Det. 32.43.\x*; pururudzirai Mwari waJakove\x + Map. 95.1. Rev. 23.24. Num.. 29.1.\x*.
 \v 2 Torai rwiyo, mugounza gandira\x + Eki. 15.20.\x*, mbira inonakidza\x + Map. 71.22.\x* pamwe nemutengeranwa\x + Map. 71.22.\x*.

--- a/Psalms/82/data
+++ b/Psalms/82/data
@@ -1,6 +1,6 @@
 \c 82
 \s Mwari ndiye mutongi mukuru
-\p Pisarema raAsafi.
+\d Pisarema raAsafi.
 \p
 \v 1 Mwari\x + 2 Makor. 19.5-7. Mup. 5.8. Mik. 7.2,3.\x* anomira paungano yemasimba\x + Isa. 3.13.\x*; anotonga\x + Map. 58.11.\x* pakati pevamwari\x + 1 Sam. 2.25. Eki. 12.12.\x*.
 \p

--- a/Psalms/83/data
+++ b/Psalms/83/data
@@ -1,6 +1,6 @@
 \c 83
 \s Munyengetero wekuti vavengi vaIsraeri vaparadzwe
-\p Rwiyo. Pisarema raAsafi.
+\d Rwiyo. Pisarema raAsafi.
 \p
 \v 1 Mwari, regai kunyarara\x + Isa. 62.7.\x*; regai kusataura, uye musati zii, Mwari\x + Map. 28.1.\x*.
 \v 2 Nokuti tarirai, vavengi venyu vanoita bope\x + Map. 39.6. 46.3. Isa. 17.12.\x*; uye vanokuvengai\x + Map. 81.15.\x* vakasimudza musoro\x + Vato. 8.28. Job. 10.15.\x*.

--- a/Psalms/84/data
+++ b/Psalms/84/data
@@ -1,6 +1,6 @@
 \c 84
 \s Mufaro uri paimba yaMwari
-\p Kumutungamiriri wekuimba. NeGititi. Kuvanakomana vaKora. Pisarema.
+\d Kumutungamiriri wekuimba. NeGititi. Kuvanakomana vaKora. Pisarema.
 \p
 \v 1 Dzinodika sei\x + Map. 27.4.\x* tabhenakeri dzenyu, Jehovha wehondo\x + Map. 43.3. 132.5,7.\x*!
 \p

--- a/Psalms/85/data
+++ b/Psalms/85/data
@@ -1,6 +1,6 @@
 \c 85
 \s Munyengetero wekukumbirira Israeri rugare
-\p Kumutungamiriri wekuimba. Kuvanakomana vaKora. Pisarema.
+\d Kumutungamiriri wekuimba. Kuvanakomana vaKora. Pisarema.
 \p
 \v 1 Jehovha, makaitira nyasha nyika yenyu; makadzosa kutapwa kwaJakove\x + Map. 14.7. 126.1,4. Ezi. 1.11. Job. 42.10.\x*.
 \v 2 Makakanganwira uipi hwevanhu venyu\x + Map. 32.1.\x*; makafukidza zvivi zvavo zvose. Sera\x + Map. 32.1.\x*.

--- a/Psalms/86/data
+++ b/Psalms/86/data
@@ -1,6 +1,6 @@
 \c 86
 \s Munyengetero wekukumbira tsitsi dzaMwari
-\p Munyengetero waDhavhidhi.
+\d Munyengetero waDhavhidhi.
 \p
 \v 1 Rerekai nzeve yenyu, Jehovha, ndipindurei\x + Map. 17.6. 31.2. 71.2. 88.2. 102.2. 116. 2.\x*; nokuti ndiri murombo nemushaiwi\x + Map. 40.17. 70.5. Map. 35.10. 37.14. 74.21. 109.16,22.\x*.
 \v 2 Chengetedzai mweya wangu; nokuti ndiri wakatendeka; imwi Mwari wangu, ponesai muranda wenyu anovimba nemwi\x + Isa. 26.3. Map. 25.2.\x*.

--- a/Psalms/87/data
+++ b/Psalms/87/data
@@ -1,6 +1,6 @@
 \c 87
 \s Mbiri yeJerusarema
-\p Kuvanakomana vaKora. Pisarema, rwiyo.
+\d Kuvanakomana vaKora. Pisarema, rwiyo.
 \p
 \v 1 Nheyo dzake\x + Isa. 28.16.\x* dziri pamusoro pemakomo matsvene\x + Map. 121.1. 133.3. Map. 48.1. Map. 68.16. Isa. 2.2,3.\x*.
 \v 2 Jehovha anoda masuwo eZiyoni kupfuura nzvimbo dzose dzekugara dzaJakove\x + Map. 78.68.\x*.

--- a/Psalms/88/data
+++ b/Psalms/88/data
@@ -1,6 +1,6 @@
 \c 88
 \s Kuchema kwemunhu anotambudzika
-\p Rwiyo. Pisarema, kuvanakomana vaKora; kumutungamiriri wekuimba; neMaharati-Reyanoti. Masikiri yaHemani muEzirahi.
+\d Rwiyo. Pisarema, kuvanakomana vaKora; kumutungamiriri wekuimba; neMaharati-Reyanoti. Masikiri yaHemani muEzirahi.
 \p
 \v 1 Jehovha, Mwari weruponeso rwangu\x + Map. 24.5.\x*, ndakachema masikati neusiku pamberi penyu\x + Map. 22.2. Ruk. 18.7.\x*.
 \v 2 Munyengetero wangu ngauuye pamberi penyu; rerekerai nzeve yenyu kukuchema kwangu\x + Map. 86.1.\x*.

--- a/Psalms/89/data
+++ b/Psalms/89/data
@@ -1,6 +1,6 @@
 \c 89
 \s Zvivimbiso zvaJehovha
-\p Masikiri yaEtani muEzirahi.
+\d Masikiri yaEtani muEzirahi.
 \p
 \v 1 Ndichaimbira\x + Map. 101.1.\x* tsitsi dzaJehovha nekusingaperi\x + Isa. 55.3.\x*\x + Map. 36.5.\x*; nemuromo wangu ndichazivisa kutendeka kwenyu kumazera nemazera\x + 89.2,5,8,24,33,49. Map. 88.11. 119.90. 89.14,28,37.\x*\x + Map. 36.5.\x*.
 \v 2 Nokuti ndakati: Tsitsi dzichavakwa nekusingaperi\x + 89.2.\x*, muchasimbisa\x + 89.2,5,8,24,33,49. Map. 88.11. 119.90. 89.14,28,37.\x* kutendeka kwenyu mumatenga momene\x + Map. 119.89.\x*.

--- a/Psalms/9/data
+++ b/Psalms/9/data
@@ -1,6 +1,6 @@
 \c 9
 \s Dhavhidhi anovonga kurwirwa naJehovha
-\p Kumutungamiriri wekuimba; neMuti-Rabheni. Pisarema raDhavhidhi.
+\d Kumutungamiriri wekuimba; neMuti-Rabheni. Pisarema raDhavhidhi.
 \p
 \v 1 Ndichavonga Jehovha nemoyo wangu wose; ndicharondedzera zvishamiso zvenyu zvese\x + 1 Makor. 16.12,24. Map. 26.7. 40.5. Map. 131.1.\x*.
 \v 2 Ndichafara nekupembera mamuri\x + Map. 5.11.\x*; ndichaimbira zita renyu rumbidzo\x + Map. 7.17.\x*, imwi Wekumusoro-soro\x + Map. 83.18.\x*.

--- a/Psalms/90/data
+++ b/Psalms/90/data
@@ -1,6 +1,6 @@
 \c 90
 \s Kupfupika kweupenyu hwemunhu
-\p Munyengetero waMozisi, munhu waMwari.
+\d Munyengetero waMozisi, munhu waMwari.
 \p
 \v 1 Ishe, imwi maiva ugaro hwedu pazera nezera\x + Det. 33.27.\x*.
 \v 2 Makomo asati azvarwa\x + Det. 32.18.\x*\x + Job. 15.7.\x*\x + Zvir. 8.25.\x*, kana mabereka pasi nenyika\x + Job. 37.12.\x*\x + Det. 32.18.\x*\x + Zvir. 8.25.\x*, iko kubva pakusingaperi kusvika pakusingaperi, imwi muri Mwari\x + Job. 36.26.\x*.

--- a/Psalms/92/data
+++ b/Psalms/92/data
@@ -1,6 +1,6 @@
 \c 92
 \s Rwiyo rwekurumbidza Jehovha
-\p Pisarema, rwiyo rwezuva resabata.
+\d Pisarema, rwiyo rwezuva resabata.
 \p
 \v 1 Zvakanaka\x + Map. 147.1.\x* kuvonga Jehovha\x + Map. 71.22.\x*, nekuimbira zita renyu rumbidzo, imwi Wekumusoro-soro\x + Map. 71.22.\x*.
 \v 2 Kuparidza rudo rweunyoro hwenyu mangwanani\x + Map. 36.5.\x*, nekutendeka kwenyu usiku hwose\x + Map. 36.5.\x*.

--- a/Psalms/98/data
+++ b/Psalms/98/data
@@ -1,6 +1,6 @@
 \c 98
 \s Jehovha mutongi wepanyika
-\p Pisarema.
+\d Pisarema.
 \p
 \v 1 Imbirai Jehovha rwiyo rutsva\x + Map. 33.3.\x*; nokuti wakaita zvinhu zvinoshamisa\x + Map. 72.18.\x*; ruoko rwake rwerudyi, nechanza chake chitsvene, zvakamuwanira kukunda\x + Job. 40.14. Eki. 15.6. Ruk. 1.51.\x*.
 \v 2 Jehovha wakazivisa ruponeso rwake\x + Isa. 52.10. Isa. 49.6. Ruk. 2.30,31. 3.6. Mab. 13.47. 28.28.\x*; wakazarura pachena kururama kwake pameso pevahedheni\x + Isa. 52.10. Isa. 49.6. Ruk. 2.30,31. 3.6. Mab. 13.47. 28.28.\x*\x + Isa. 62.2. VaRom. 3.25,26.\x*\x + Zvir. 26.26.\x*.


### PR DESCRIPTION
Used marker \d for the title in 104 Psalms.
Also added missing \p after the title in Psalm 76.

Addresses issue #18 