### PR TITLE
Fix remaining 12 canonical Psalm title marker

### DIFF
--- a/Psalms/103/data
+++ b/Psalms/103/data
@@ -1,6 +1,6 @@
 \c 103
 \s Rumbidzai Jehovha nekuda kwetsitsi dzake
-\p \add Pisarema\add* raDhavhidhi.
+\d \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Rumbidza Jehovha, mweya wangu; nezvese zviri mukati mangu \add zvirumbidze\add* zita rake dzvene\x + 103.2,22. Map. 104.1,35. Map. 146.1.\x*.
 \v 2 Rumbidza Jehovha, mweya wangu\x + 102.2,22. Map. 104.1,35. Map. 146.1.\x*, usakanganwa mibairo yake yose\x + Det. 6.12. 8.11.\x*.

--- a/Psalms/138/data
+++ b/Psalms/138/data
@@ -1,6 +1,6 @@
 \c 138
 \s Kuvonga Jehovha
-\p \add Pisarema\add* raDhavhidhi.
+\d \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Ndichakuvongai nemoyo wangu wose; ndichakuimbirai rumbidzo pamberi pevamwari.
 \v 2 Ndichanamata \add ndakatarira\add* kutembere yenyu tsvene, nekurumbidza zita renyu nekuda kweunyoro hwenyu uye nekuda kwekutendeka kwenyu; nokuti makakurisa shoko renyu pamusoro pezita renyu rose.

--- a/Psalms/144/data
+++ b/Psalms/144/data
@@ -1,6 +1,6 @@
 \c 144
 \s Kukunda nekubudirira zvinobva kuna Jehovha
-\p \add Pisarema\add* raDhavhidhi.
+\d \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Ngaarumbidzwe Jehovha, dombo rangu, anodzidzisira maoko angu hondo, mimwe yangu kurwa;
 \v 2 unyoro hwangu, nenhare yangu, shongwe yangu yakakwirira, nemununuri wangu kwandiri; nhovo yangu, uye iye wandinovimba naye; anoisa vanhu vangu pasi pangu.

--- a/Psalms/25/data
+++ b/Psalms/25/data
@@ -1,6 +1,6 @@
 \c 25
 \s Munyengetero wekukumbira kutungamirirwa, kangamwiro nekuchengetedzwa
-\p \add Pisarema\add* raDhavhidhi.
+\d \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Kwamuri Jehovha, ndinosimudzira mweya wangu\x + Map. 86.4. 143.8. Marir. 3.41. Det. 24.15. Map. 24.4.\x*.
 \v 2 Mwari wangu, ndinovimba nemwi\x + Map. 22.4,5. 26.1. 28.7. 32.10. 37.3. 40.3. 55.23. 56.4,11. 84.12. 91.2. 112.7. 115.9-11. 125.1. 143.8. Zvir. 16.20. 29.25. Jer. 17.7. Map. 4.5. 11.1. 13.5. 16.1. 31.1,6,14. 33.21. 34.8. 37.5,40. 56.3. 57.1. 62.8. 64.10. 71.1. 86.2. 118.8,9. 141.8. Zvir. 3.5. Isa. 28.16. Dhan. 3.28. Map. 2.12.\x*, ngandirege kunyadziswa\x + 25.20. Map. 31.1,17. 71.1. Isa. 49.23. Map. 119.116.\x*; vavengi vangu ngavarege kupemberera pamusoro pangu\x + Map. 13.4.\x*.

--- a/Psalms/26/data
+++ b/Psalms/26/data
@@ -1,6 +1,6 @@
 \c 26
 \s Munhu asina mhosva anonyengeterera kururamisirwa
-\p \add Pisarema\add* raDhavhidhi.
+\d \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Nditongerei Jehovha\x + Map. 7.8. 35.24. 43.1.\x*, nokuti ini ndakafamba muuchokwadi hwangu\x + 26.11. Zvir. 20.7.\x*; ndakavimbawo naJehovha\x + Map. 25.2.\x*; handitedzemuki\x + Map. 18.36. 37.31.\x*.
 \v 2 Ndinzverei Jehovha, mugondiedza\x + Vato. 7.4.\x*; natsurudzai\x + Map. 7.9. 17.3. 66.10. 139.23. Zek. 13.9.\x* itsvo dzangu nemoyo wangu\x + Map. 7.9.\x*.

--- a/Psalms/27/data
+++ b/Psalms/27/data
@@ -1,6 +1,6 @@
 \c 27
 \s Jehovha ndiye chiedza nemuponesi
-\p \add Pisarema\add* raDhavhidhi.
+\d \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Jehovha chiedza changu\x + Isa. 60.20. Mik. 7.8. Map. 84.11.\x* neruponeso rwangu\x + Map. 118.14. Eki. 15.2.\x*; ndiani wandingatya\x + Map. 23.4.\x*? Jehovha isimba reupenyu hwangu; ndiani wandingabvunda\x + Map. 118.14. Eki. 15.2.\x*?
 \v 2 Pakaswedera kwandiri vakaipa, vavengi vangu, nevadzivisi vangu kwandiri, kuzodya nyama yangu, ivo vakagumburwa vakawa\x + Map. 14.4.\x*.

--- a/Psalms/28/data
+++ b/Psalms/28/data
@@ -1,6 +1,6 @@
 \c 28
 \s Munyengetero wekukumbira rubatsiro
-\p \add Pisarema\add* raDhavhidhi.
+\d \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Ndichadana kwamuri, Jehovha; dombo rangu\x + Map. 18.2.\x*, regai kundinyararira\x + Map. 35.22. 39.12. 83.1. 109.1.\x*; zvimwe \add kana\add* mukandinyararira ndingafanana\x + Map. 143.7. Zvir. 1.12. Map. 30.3.\x* nevanoburukira kugomba\x + Map. 143.7. Zvir. 1.12. Map. 30.3.\x*\x + Map. 88.4.\x*.
 \v 2 Inzwai inzwi remikumbiro yangu, kana ndichichemera rubatsiro kwamuri\x + 28.2. Map. 140.6.\x*, kana ndichisimudzira maoko angu\x + Map. 134.2. Map. 119.48.\x* kunzvimbo yenyu\x + 1 Madz. 8.29.\x* yeinzwi dzvene\x + 1 Madz. 6.5. Map. 138.2.\x*.

--- a/Psalms/32/data
+++ b/Psalms/32/data
@@ -1,6 +1,6 @@
 \c 32
 \s Mufaro wemunhu wakakanganwirwa zvivi zvake
-\p \add Pisarema\add* raDhavhidhi. Masikiri.
+\d \add Pisarema\add* raDhavhidhi. Masikiri.
 \p
 \v 1 Wakaropafadzwa uyo chitadzo chake chakakanganwirwa, chivi chake chakafukidzirwa\x + VaRom. 4.7,8. Map. 85.2.\x*.
 \v 2 Wakaropafadzwa munhu Jehovha waasingaverengeri chakaipa\x + 2 VaKori. 5.19.\x*, uye pasina kunyengera pamweya wake\x + Joh. 1.47.\x*.

--- a/Psalms/34/data
+++ b/Psalms/34/data
@@ -1,6 +1,6 @@
 \c 34
 \s Jehovha anobatsira vanotenda kwaari
-\p \add Pisarema\add* raDhavhidhi, paakazviita benzi pamberi paAbhimereki\x + 1 Sam. 21.13.\x*, iye akamudzinga\x + 1 Sam. 21.14,15. 22.1.\x*, akaenda\x + 1 Sam. 21.14,15. 22.1.\x*.
+\d \add Pisarema\add* raDhavhidhi, paakazviita benzi pamberi paAbhimereki\x + 1 Sam. 21.13.\x*, iye akamudzinga\x + 1 Sam. 21.14,15. 22.1.\x*, akaenda\x + 1 Sam. 21.14,15. 22.1.\x*.
 \p
 \v 1 Ndicharumbidza Jehovha panguva dzose; rumbidzo yake icharamba iri mumuromo mangu\x + VaEfe. 5.20.\x*.
 \v 2 Mweya wangu\x + Map. 33.20.\x* uchazvirumbidza muna Jehovha\x + Jer. 9.24. Ruk. 1.46. Map. 44.8.\x*; vanyoro vachazvinzwa, vakafara\x + Map. 119.74.\x*.

--- a/Psalms/35/data
+++ b/Psalms/35/data
@@ -1,6 +1,6 @@
 \c 35
 \s Dhavhidhi anokumbira kuti vakaipa varohwe
-\p \add Pisarema\add* raDhavhidhi.
+\d \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Kakavadzanai, Jehovha\x + 1 Sam. 24.15.\x*, nevanokakavadzana neni; irwai nevanorwa neni\x + Isa. 49.25.\x*.
 \v 2 Batisisai nhovo huru nenhovo diki\x + Map. 91.4. Map. 5.12.\x*, musimukire rubatsiro rwangu\x + Map. 38.22.\x*.

--- a/Psalms/37/data
+++ b/Psalms/37/data
@@ -1,6 +1,6 @@
 \c 37
 \s Mufaro wevakaipa ndewenguva diki
-\p \add Pisarema\add* raDhavhidhi.
+\d \add Pisarema\add* raDhavhidhi.
 \p
 \v 1 Usashungurudzika nekuda kwevaiti vezvakaipa\x + 37.7,8. Zvir. 24.19.\x*; usagodora vabati vezvakaipa\x + Map. 73.3. Zvir. 3.31. 23.17. 24.1,19.\x*.
 \v 2 Nokuti vachakurumidza kugurwa\x + Job. 14.2.\x* seuswa, nekusvava seuswa unyoro\x + Map. 90.5,6.\x*.

--- a/Psalms/72/data
+++ b/Psalms/72/data
@@ -1,6 +1,6 @@
 \c 72
 \s Ukuru hwaMambo
-\p \add Pisarema\add* raSoromoni.
+\d \add Pisarema\add* raSoromoni.
 \p
 \v 1 Mwari, ipai mambo mitongo yenyu, nekururama kwenyu\x + 1 Makor. 22.12.\x* kumwanakomana wamambo\x + Isa. 19.11.\x*.
 \v 2 Achatonga vanhu venyu nekururama, nevarombo venyu nemutongo wakarurama\x + Isa. 11.3,4. 32.1.\x*.


### PR DESCRIPTION
Used **\d** for the 12 Psalms that were inadvertently omitted in my previous commit.

The text of these 12 titles begins with the **\add ** marker.

Psalms 25,26,27,28,32,34,35,37,72,103,138,144 hereby updated accordingly.

